### PR TITLE
fix: resolve auth timeout and ExpiredTokenError in multi-worker envir…

### DIFF
--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -58,6 +58,8 @@ class ClerkState(rx.State):
         "nbf": {"essential": True},
         # "azp": {"essential": False, "values": ["http://localhost:3000", "https://example.com"]},
     }
+    _jwt_validate_leeway_seconds: ClassVar[int] = 60
+    """Clock-skew leeway (seconds) for validating JWT claims like exp/nbf."""
 
     @classmethod
     def register_dependent_handler(cls, handler: EventCallback) -> None:
@@ -83,6 +85,15 @@ class ClerkState(rx.State):
     def set_claims_options(cls, claims_options: dict[str, Any]) -> None:
         """Set the claims options for the JWT claims validation."""
         cls._claims_options = claims_options
+
+    @classmethod
+    def set_jwt_validate_leeway_seconds(cls, seconds: int) -> None:
+        """Set clock-skew leeway (seconds) for JWT exp/nbf validation.
+
+        Default is 60 seconds. Increase if you see intermittent ExpiredTokenError
+        due to clock drift between Clerk servers and your backend.
+        """
+        cls._jwt_validate_leeway_seconds = seconds
 
     @property
     def client(self) -> clerk_backend_api.Clerk:
@@ -115,9 +126,13 @@ class ClerkState(rx.State):
             return ClerkState.clear_clerk_session
         try:
             # Validate the token according to the claim options (e.g. iss, exp, nbf, azp.)
-            decoded.validate()
-        except (jose_errors.InvalidClaimError, jose_errors.MissingClaimError) as e:
-            logging.warning(f"JWT token is invalid: {e}")
+            decoded.validate(leeway=self._jwt_validate_leeway_seconds)
+        except (
+            jose_errors.ExpiredTokenError,
+            jose_errors.InvalidClaimError,
+            jose_errors.MissingClaimError,
+        ) as e:
+            logging.warning(f"JWT token validation failed: {type(e).__name__}: {e}")
             return ClerkState.clear_clerk_session
 
         async with self:
@@ -300,7 +315,7 @@ class ClerkSessionSynchronizer(rx.Component):
     ) -> rx.ImportDict:
         addl_imports: rx.ImportDict = {
             "@clerk/clerk-react": ["useAuth"],
-            "react": ["useContext", "useEffect"],
+            "react": ["useContext", "useEffect", "useRef"],
             "$/utils/context": ["EventLoopContext"],
             "$/utils/state": ["ReflexEvent"],
         }
@@ -313,26 +328,50 @@ class ClerkSessionSynchronizer(rx.Component):
             """
 function ClerkSessionSynchronizer({ children }) {
   const { getToken, isLoaded, isSignedIn } = useAuth()
-  const [ addEvents, connectErrors ] = useContext(EventLoopContext)
+  const [ addEvents ] = useContext(EventLoopContext)
+  const lastSentRef = useRef({ stateKey: null, addEvents: null })
 
   useEffect(() => {
-      if (isLoaded && !!addEvents) {
-        if (isSignedIn) {
-          getToken().then(token => {
-            addEvents([ReflexEvent("%s.set_clerk_session", {token})])
+      // Wait for all dependencies to be ready.
+      if (!isLoaded || !addEvents) return
+
+      // Deduplicate rapid calls, but remain reconnect-safe:
+      // addEvents identity changes across websocket reconnects, so include it in the key.
+      const stateKey = isSignedIn ? "signed_in" : "signed_out"
+      if (
+        lastSentRef.current?.stateKey === stateKey &&
+        lastSentRef.current?.addEvents === addEvents
+      ) return
+      lastSentRef.current = { stateKey, addEvents }
+
+      if (isSignedIn) {
+        // Prefer a fresh token; cached tokens can be close to expiry.
+        // If this Clerk version doesn't support skipCache, fall back to the default call.
+        Promise.resolve()
+          .then(() => getToken({ skipCache: true }))
+          .catch(() => getToken())
+          .then(token => {
+            if (token) {
+              addEvents([ReflexEvent("%s.set_clerk_session", {token})])
+            } else {
+              // Token unavailable despite isSignedIn - clear to avoid stuck auth state.
+              addEvents([ReflexEvent("%s.clear_clerk_session")])
+            }
+          }).catch(() => {
+            // Token retrieval failed - clear to avoid stuck auth state.
+            addEvents([ReflexEvent("%s.clear_clerk_session")])
           })
-        } else {
-          addEvents([ReflexEvent("%s.clear_clerk_session")])
-        }
+      } else {
+        addEvents([ReflexEvent("%s.clear_clerk_session")])
       }
-  }, [isSignedIn])
+  }, [isLoaded, isSignedIn, addEvents, getToken])
 
   return (
       <>{children}</>
   )
 }
 """
-            % (clerk_state_name, clerk_state_name)
+            % (clerk_state_name, clerk_state_name, clerk_state_name, clerk_state_name)
         ]
 
 

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -99,7 +99,7 @@ class ClerkState(rx.State):
         Raises:
             ValueError: If seconds is negative or exceeds 3600.
         """
-        if not isinstance(seconds, int) or seconds < 0:
+        if not isinstance(seconds, int) or isinstance(seconds, bool) or seconds < 0:
             raise ValueError(
                 f"jwt_validate_leeway_seconds must be a non-negative integer, got {seconds!r}"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ homepage = "https://reflex-clerk-api-demo.adventuresoftim.com"
 
 [tool.pytest.ini_options]
 # addopts = "--headed"
+pythonpath = ["custom_components"]
 
 [tool.pyright]
 venvPath = "."

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -1,13 +1,6 @@
 import asyncio
-import sys
-from pathlib import Path
 
 import authlib.jose.errors as jose_errors
-
-
-# Ensure tests use the local custom component code (not an installed wheel).
-_CUSTOM_COMPONENTS_DIR = Path(__file__).resolve().parents[1] / "custom_components"
-sys.path.insert(0, str(_CUSTOM_COMPONENTS_DIR))
 
 
 def test_set_clerk_session_expired_token_clears(monkeypatch):

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import authlib.jose.errors as jose_errors
+
+
+# Ensure tests use the local custom component code (not an installed wheel).
+_CUSTOM_COMPONENTS_DIR = Path(__file__).resolve().parents[1] / "custom_components"
+sys.path.insert(0, str(_CUSTOM_COMPONENTS_DIR))
+
+
+def test_set_clerk_session_expired_token_clears(monkeypatch):
+    """Expired tokens should not crash the handler; they should clear session."""
+    # Import inside the test so the module is importable in different test layouts.
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    import importlib
+
+    clerk_provider_module = importlib.import_module("reflex_clerk_api.clerk_provider")
+
+    # Instantiate state in a framework-safe way for tests.
+    state = ClerkState(_reflex_internal_init=True)
+
+    async def fake_get_jwk_keys(self):
+        return {}
+
+    monkeypatch.setattr(ClerkState, "_get_jwk_keys", fake_get_jwk_keys, raising=True)
+
+    validate_calls: dict[str, object] = {}
+
+    class FakeClaims:
+        def validate(self, leeway=None):
+            validate_calls["leeway"] = leeway
+            raise jose_errors.ExpiredTokenError()
+
+    monkeypatch.setattr(
+        clerk_provider_module.jwt,
+        "decode",
+        lambda *args, **kwargs: FakeClaims(),
+        raising=True,
+    )
+
+    result = asyncio.run(ClerkState.set_clerk_session.fn(state, token="fake"))
+    assert validate_calls["leeway"] == 60
+    assert result == ClerkState.clear_clerk_session
+
+
+def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcache():
+    """String-based regression test for the generated JS."""
+    from reflex_clerk_api.clerk_provider import ClerkSessionSynchronizer
+
+    js = ClerkSessionSynchronizer.create().add_custom_code()[0]
+    assert "[isLoaded, isSignedIn, addEvents, getToken]" in js
+    assert "skipCache: true" in js
+
+

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -13,11 +13,13 @@ sys.path.insert(0, str(_CUSTOM_COMPONENTS_DIR))
 def test_set_clerk_session_expired_token_clears(monkeypatch):
     """Expired tokens should not crash the handler; they should clear session."""
     # Import inside the test so the module is importable in different test layouts.
-    from reflex_clerk_api.clerk_provider import ClerkState
-
+    # We need the actual module object (not just ClerkState) to monkeypatch jwt.decode
+    # where it's used. importlib is required because reflex_clerk_api.clerk_provider
+    # resolves to the function via __init__.py re-exports.
     import importlib
 
     clerk_provider_module = importlib.import_module("reflex_clerk_api.clerk_provider")
+    from reflex_clerk_api.clerk_provider import ClerkState
 
     # Instantiate state in a framework-safe way for tests.
     state = ClerkState(_reflex_internal_init=True)
@@ -53,5 +55,3 @@ def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcach
     js = ClerkSessionSynchronizer.create().add_custom_code()[0]
     assert "[isLoaded, isSignedIn, addEvents, getToken]" in js
     assert "skipCache: true" in js
-
-


### PR DESCRIPTION
…onments

Frontend (ClerkSessionSynchronizer):
- Fix useEffect deps: [isSignedIn] -> [isLoaded, isSignedIn, addEvents, getToken]
- Add reconnect-safe resend via dedupe guard keyed on (stateKey, addEvents identity)
- Request fresh token with skipCache:true to avoid near-expiry tokens
- Clear session on token fetch failure to prevent stuck auth_checked=false

Backend (ClerkState.set_clerk_session):
- Add 60s leeway to JWT validation for clock skew tolerance
- Catch ExpiredTokenError (in addition to existing InvalidClaimError/MissingClaimError)
- Return clear_clerk_session on validation failure instead of raising
- Add set_jwt_validate_leeway_seconds() for downstream configuration

Tests:
- Add unit test for ExpiredTokenError -> clear session path
- Add JS string assertion for correct deps array and skipCache

Fixes: Authentication timeout after max attempts, auth not ready after timeout, ExpiredTokenError crashes in set_clerk_session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release Notes

## New Features
- Configurable JWT validation leeway: Added ClerkState.set_jwt_validate_leeway_seconds(seconds) to adjust clock-skew tolerance for JWT validation (default 60s).

## Improvements
- Frontend token synchronization: ClerkSessionSynchronizer now uses reconnect-safe, deduplicated resend logic (useRef-based) to avoid repeated requests across reconnects/workers.
- Fresh token requests: Token retrieval requests fresh tokens with skipCache: true to avoid near-expiry tokens when possible.
- Improved JWT validation handling: set_clerk_session validates tokens using the configured leeway and logs clearer validation failures.
- useEffect dependency accuracy: Frontend deps expanded to [isLoaded, isSignedIn, addEvents, getToken] to correctly react to relevant state changes.
- Validation hardening: jwt_validate_leeway_seconds input validated as a non-negative integer (≤ 3600).

## Bug Fixes
- Prevent auth timeout/stuck state: Clear session on token fetch failure to avoid auth_checked remaining false and authentication timeouts in multi-worker environments.
- Handle expired tokens safely: Catch ExpiredTokenError (in addition to InvalidClaimError and MissingClaimError) in set_clerk_session and return clear_clerk_session instead of raising/crashing.
- Fix "auth not ready" after timeout and related multi-worker auth timing issues.

## Chores
- Tests added:
  - Unit test ensuring ExpiredTokenError triggers session-clear path.
  - JS string assertion test verifying ClerkSessionSynchronizer deps array and skipCache usage.
- Pytest config updated: added pythonpath = ["custom_components"] to pyproject.toml to include custom components for tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->