### PR TITLE
Pin Clerk frontend version set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ def index() -> rx.Component:
     )
 ```
 
+The package pins a compatible Clerk frontend set by default (`@clerk/react@6.6.0`, `@clerk/ui@1.9.0`, ClerkJS `6.10.0`). Apps that need another compatible set can call `clerk.configure_clerk_frontend_versions(...)` before creating Clerk components.
+
 ## Contributing
 
 Feel free to open issues or make PRs.

--- a/custom_components/reflex_clerk_api/__init__.py
+++ b/custom_components/reflex_clerk_api/__init__.py
@@ -1,6 +1,21 @@
-__version__ = "1.2.4"
+__version__ = "1.3.0"
 
 from .authentication_components import sign_in, sign_up
+from .base import (
+    CLERK_JS_VERSION,
+    CLERK_REACT_LIBRARY,
+    CLERK_REACT_VERSION,
+    CLERK_UI_LIBRARY,
+    CLERK_UI_VERSION,
+    DEFAULT_CLERK_FRONTEND_VERSIONS,
+    ClerkFrontendVersions,
+    configure_clerk_frontend_versions,
+    get_clerk_frontend_versions,
+    get_clerk_react_library,
+    get_clerk_ui_library,
+    reset_clerk_frontend_versions,
+)
+from .billing_components import pricing_table
 from .clerk_provider import (
     ClerkState,
     ClerkUser,
@@ -16,7 +31,12 @@ from .control_components import (
     redirect_to_user_profile,
     show,
 )
-from .billing_components import pricing_table
+from .organization_components import (
+    create_organization,
+    organization_list,
+    organization_profile,
+    organization_switcher,
+)
 from .pages import add_sign_in_page, add_sign_up_page
 from .unstyled_components import (
     SignInButton,
@@ -25,14 +45,15 @@ from .unstyled_components import (
     sign_up_button,
 )
 from .user_components import user_button, user_profile
-from .organization_components import (
-    create_organization,
-    organization_profile,
-    organization_switcher,
-    organization_list,
-)
 
 __all__ = [
+    "CLERK_JS_VERSION",
+    "CLERK_REACT_LIBRARY",
+    "CLERK_REACT_VERSION",
+    "CLERK_UI_LIBRARY",
+    "CLERK_UI_VERSION",
+    "DEFAULT_CLERK_FRONTEND_VERSIONS",
+    "ClerkFrontendVersions",
     "ClerkState",
     "ClerkUser",
     "SignInButton",
@@ -41,7 +62,11 @@ __all__ = [
     "clerk_loaded",
     "clerk_loading",
     "clerk_provider",
+    "configure_clerk_frontend_versions",
     "create_organization",
+    "get_clerk_frontend_versions",
+    "get_clerk_react_library",
+    "get_clerk_ui_library",
     "on_load",
     "organization_list",
     "organization_profile",
@@ -49,12 +74,13 @@ __all__ = [
     "pricing_table",
     "redirect_to_user_profile",
     "register_on_auth_change_handler",
+    "reset_clerk_frontend_versions",
+    "show",
     "sign_in",
     "sign_in_button",
     "sign_out_button",
     "sign_up",
     "sign_up_button",
-    "show",
     "update_user_phone_number",
     "user_button",
     "user_profile",

--- a/custom_components/reflex_clerk_api/base.py
+++ b/custom_components/reflex_clerk_api/base.py
@@ -1,7 +1,163 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, replace
+
 import reflex as rx
+
+
+def _versioned_package(package: str, version: str) -> str:
+    return f"{package}@{version}"
+
+
+@dataclass(frozen=True)
+class ClerkFrontendVersions:
+    """Frontend package versions that must stay compatible with each other."""
+
+    react_version: str
+    ui_version: str
+    clerk_js_version: str
+    shared_version: str | None = None
+    localizations_version: str | None = None
+    tanstack_query_core_version: str | None = None
+
+    @property
+    def react_library(self) -> str:
+        """The versioned @clerk/react package import used by Reflex."""
+        return _versioned_package("@clerk/react", self.react_version)
+
+    @property
+    def ui_library(self) -> str:
+        """The versioned @clerk/ui package import used by Reflex."""
+        return _versioned_package("@clerk/ui", self.ui_version)
+
+    @property
+    def dependency_libraries(self) -> tuple[str, ...]:
+        """Additional frontend dependencies to install alongside Clerk."""
+        dependencies = (
+            ("@clerk/shared", self.shared_version),
+            ("@clerk/localizations", self.localizations_version),
+            ("@tanstack/query-core", self.tanstack_query_core_version),
+        )
+        return tuple(
+            _versioned_package(package, version)
+            for package, version in dependencies
+            if version is not None
+        )
+
+
+DEFAULT_CLERK_FRONTEND_VERSIONS = ClerkFrontendVersions(
+    react_version="6.6.0",
+    ui_version="1.9.0",
+    clerk_js_version="6.10.0",
+    shared_version="4.10.1",
+    localizations_version="4.6.1",
+    tanstack_query_core_version="5.100.9",
+)
+
+CLERK_REACT_VERSION = DEFAULT_CLERK_FRONTEND_VERSIONS.react_version
+CLERK_UI_VERSION = DEFAULT_CLERK_FRONTEND_VERSIONS.ui_version
+CLERK_JS_VERSION = DEFAULT_CLERK_FRONTEND_VERSIONS.clerk_js_version
+CLERK_REACT_LIBRARY = DEFAULT_CLERK_FRONTEND_VERSIONS.react_library
+CLERK_UI_LIBRARY = DEFAULT_CLERK_FRONTEND_VERSIONS.ui_library
+
+_clerk_frontend_versions = DEFAULT_CLERK_FRONTEND_VERSIONS
 
 
 class ClerkBase(rx.Component):
     # The React library to wrap.
     # `Show` is exported from `@clerk/react` (v6+), not `@clerk/clerk-react`.
-    library = "@clerk/react@^6.2.0"
+    library = CLERK_REACT_LIBRARY
+    lib_dependencies = list(DEFAULT_CLERK_FRONTEND_VERSIONS.dependency_libraries)
+
+    def __init_subclass__(cls, **kwargs):
+        """Keep future subclasses aligned with the active frontend version set."""
+        super().__init_subclass__(**kwargs)
+        _sync_clerk_component_class(cls)
+
+
+def get_clerk_frontend_versions() -> ClerkFrontendVersions:
+    """Return the active Clerk frontend version set."""
+    return _clerk_frontend_versions
+
+
+def get_clerk_react_library() -> str:
+    """Return the active versioned @clerk/react package name."""
+    return _clerk_frontend_versions.react_library
+
+
+def get_clerk_ui_library() -> str:
+    """Return the active versioned @clerk/ui package name."""
+    return _clerk_frontend_versions.ui_library
+
+
+def configure_clerk_frontend_versions(
+    versions: ClerkFrontendVersions | None = None,
+    *,
+    react_version: str | None = None,
+    ui_version: str | None = None,
+    clerk_js_version: str | None = None,
+    shared_version: str | None = None,
+    localizations_version: str | None = None,
+    tanstack_query_core_version: str | None = None,
+) -> ClerkFrontendVersions:
+    """Configure the Clerk frontend packages emitted by Reflex.
+
+    Call this before creating pages/components if an app needs to override the
+    package defaults. Already-imported Clerk component classes are updated too,
+    including Reflex's stored field defaults.
+    """
+    global _clerk_frontend_versions
+
+    next_versions = versions or _clerk_frontend_versions
+    replacements = {
+        "react_version": react_version,
+        "ui_version": ui_version,
+        "clerk_js_version": clerk_js_version,
+        "shared_version": shared_version,
+        "localizations_version": localizations_version,
+        "tanstack_query_core_version": tanstack_query_core_version,
+    }
+    next_versions = replace(
+        next_versions,
+        **{key: value for key, value in replacements.items() if value is not None},
+    )
+
+    _clerk_frontend_versions = next_versions
+    for component_cls in _iter_clerk_component_classes():
+        _sync_clerk_component_class(component_cls)
+    return next_versions
+
+
+def reset_clerk_frontend_versions() -> ClerkFrontendVersions:
+    """Reset Clerk frontend packages to the package defaults."""
+    return configure_clerk_frontend_versions(DEFAULT_CLERK_FRONTEND_VERSIONS)
+
+
+def _sync_clerk_component_class(component_cls: type[rx.Component]) -> None:
+    """Sync class attributes and Reflex field defaults for Clerk components."""
+    versions = get_clerk_frontend_versions()
+    component_cls.library = versions.react_library
+    component_cls.lib_dependencies = list(versions.dependency_libraries)
+
+    fields = component_cls.get_fields()
+    if "library" in fields:
+        fields["library"].default = versions.react_library
+    if "lib_dependencies" in fields:
+        fields["lib_dependencies"].default = list(versions.dependency_libraries)
+    if "clerk_js_version" in fields:
+        setattr(component_cls, "clerk_js_version", versions.clerk_js_version)
+        fields["clerk_js_version"].default = versions.clerk_js_version
+
+
+def _iter_clerk_component_classes() -> Iterator[type[rx.Component]]:
+    yield ClerkBase
+    yield from _iter_clerk_component_subclasses(ClerkBase)
+
+
+def _iter_clerk_component_subclasses(
+    component_cls: type[rx.Component],
+) -> Iterator[type[rx.Component]]:
+    for subclass in component_cls.__subclasses__():
+        yield subclass
+        yield from _iter_clerk_component_subclasses(subclass)

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -14,7 +14,12 @@ from reflex.event import EventCallback, EventType, IndividualEventType
 from reflex.utils.exceptions import ImmutableStateError
 from reflex.vars.base import Var
 
-from reflex_clerk_api.base import ClerkBase
+from reflex_clerk_api.base import (
+    ClerkBase,
+    get_clerk_frontend_versions,
+    get_clerk_react_library,
+    get_clerk_ui_library,
+)
 
 from .models import Appearance
 
@@ -420,7 +425,7 @@ class ClerkSessionSynchronizer(rx.Component):
         self,
     ) -> rx.ImportDict:
         addl_imports: rx.ImportDict = {
-            "@clerk/react": ["useAuth"],
+            get_clerk_react_library(): ["useAuth"],
             "react": ["useContext", "useEffect", "useRef"],
             "$/utils/context": ["EventLoopContext"],
             "$/utils/state": ["ReflexEvent"],
@@ -552,7 +557,7 @@ class ClerkProvider(ClerkBase):
     clerk_js_variant: str | None = None
     """If your web application only uses control components, set this to 'headless'."""
 
-    clerk_js_version: str = ""
+    clerk_js_version: str = get_clerk_frontend_versions().clerk_js_version
     """Define the npm version for @clerk/clerk-js."""
 
     # domain: str | JSCallable[[str], bool] = ""
@@ -634,13 +639,16 @@ class ClerkProvider(ClerkBase):
 
     def add_imports(self) -> rx.ImportDict:
         # Import ui package to pin Clerk component versions when using structural CSS.
-        return {"@clerk/ui": ["ui"]}
+        return {get_clerk_ui_library(): ["ui"]}
 
     @classmethod
     def create(cls, *children, **props) -> Self:
         # Default to ui={ui} unless caller explicitly supplies a different ui config.
         if "ui" not in props:
             props["ui"] = Var(_js_expr="ui", _var_type=Any)
+        props.setdefault(
+            "clerk_js_version", get_clerk_frontend_versions().clerk_js_version
+        )
         return cast(Self, super().create(*children, **props))
 
     def add_custom_code(self) -> list[str]:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -101,6 +101,28 @@ clerk.wrap_app(app, publishable_key=...)
 
 Taking the same arguments as `clerk.clerk_provider`.
 
+### Frontend Package Versions
+
+`reflex-clerk-api` pins a compatible Clerk frontend set by default:
+
+- `@clerk/react@6.6.0`
+- `@clerk/ui@1.9.0`
+- ClerkJS `6.10.0`
+
+If your app needs a different compatible set, configure it before creating Clerk components or importing page modules that create them:
+
+```python
+import reflex_clerk_api as clerk
+
+clerk.configure_clerk_frontend_versions(
+    react_version="6.6.0",
+    ui_version="1.9.0",
+    clerk_js_version="6.10.0",
+)
+```
+
+The configuration updates both `ClerkBase.library` and Reflex's stored component field defaults, so `clerk_provider(...)`, `wrap_app(...)`, and direct `ClerkProvider.create(...)` calls use the same version set.
+
 ### Environment Variables
 
 A good way to provide the keys is via environment variables (to avoid accidentally sharing them). You can do this by creating a `.env` file in the root of your project with:

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -1,6 +1,8 @@
 import asyncio
 
 import authlib.jose.errors as jose_errors
+import reflex as rx
+from reflex.utils.imports import ImportVar
 
 
 def test_set_clerk_session_expired_token_clears(monkeypatch):
@@ -53,11 +55,42 @@ def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcach
     assert "isJwtExpired(token)" in js
 
 
+def test_clerk_session_synchronizer_imports_pinned_clerk_react():
+    from reflex_clerk_api.base import CLERK_REACT_LIBRARY
+    from reflex_clerk_api.clerk_provider import ClerkSessionSynchronizer
+
+    imports = ClerkSessionSynchronizer.create().add_imports()
+    assert imports.get(CLERK_REACT_LIBRARY) == ["useAuth"]
+    assert "@clerk/react" not in imports
+
+
+def test_clerk_base_components_import_pinned_clerk_react():
+    from reflex_clerk_api.base import (
+        CLERK_REACT_LIBRARY,
+        CLERK_REACT_VERSION,
+        DEFAULT_CLERK_FRONTEND_VERSIONS,
+        ClerkBase,
+    )
+    from reflex_clerk_api.user_components import UserButton
+
+    component = UserButton.create()
+    imports = component._get_imports()
+    assert ClerkBase.library == f"@clerk/react@{CLERK_REACT_VERSION}"
+    assert component.library == CLERK_REACT_LIBRARY
+    assert UserButton.get_fields()["library"].default == CLERK_REACT_LIBRARY
+    assert CLERK_REACT_LIBRARY in imports
+    for dependency in DEFAULT_CLERK_FRONTEND_VERSIONS.dependency_libraries:
+        assert dependency in imports
+        assert all(import_var.render is False for import_var in imports[dependency])
+
+
 def test_clerk_provider_adds_clerk_ui_import_by_default():
+    from reflex_clerk_api.base import CLERK_UI_LIBRARY
     from reflex_clerk_api.clerk_provider import ClerkProvider
 
     imports = ClerkProvider.create().add_imports()
-    assert imports.get("@clerk/ui") == ["ui"]
+    assert imports.get(CLERK_UI_LIBRARY) == ["ui"]
+    assert "@clerk/ui" not in imports
 
 
 def test_clerk_provider_defaults_ui_prop_to_imported_ui_symbol():
@@ -72,3 +105,110 @@ def test_clerk_provider_allows_ui_override():
 
     props = ClerkProvider.create(ui="custom-ui").render()["props"]
     assert 'ui:"custom-ui"' in props
+
+
+def test_clerk_provider_defaults_clerk_js_version():
+    from reflex_clerk_api.base import CLERK_JS_VERSION
+    from reflex_clerk_api.clerk_provider import ClerkProvider, clerk_provider
+
+    assert f'clerkJsVersion:"{CLERK_JS_VERSION}"' in ClerkProvider.create().render()[
+        "props"
+    ]
+    assert f'clerkJsVersion:"{CLERK_JS_VERSION}"' in clerk_provider(
+        publishable_key="pk_test"
+    ).render()["props"]
+
+
+def test_clerk_provider_allows_clerk_js_version_override():
+    from reflex_clerk_api.clerk_provider import ClerkProvider, clerk_provider
+
+    assert 'clerkJsVersion:"6.99.0"' in ClerkProvider.create(
+        clerk_js_version="6.99.0"
+    ).render()["props"]
+    assert 'clerkJsVersion:"6.99.0"' in clerk_provider(
+        publishable_key="pk_test",
+        clerk_js_version="6.99.0",
+    ).render()["props"]
+
+
+def test_wrap_app_defaults_clerk_js_version():
+    from reflex_clerk_api.base import CLERK_JS_VERSION
+    from reflex_clerk_api.clerk_provider import wrap_app
+
+    app = rx.App()
+    wrap_app(app, publishable_key="pk_test")
+
+    component = app.app_wraps[(1, "ClerkProvider")](None)
+    assert f'clerkJsVersion:"{CLERK_JS_VERSION}"' in component.render()["props"]
+
+
+def test_wrap_app_allows_clerk_js_version_override():
+    from reflex_clerk_api.clerk_provider import wrap_app
+
+    app = rx.App()
+    wrap_app(app, publishable_key="pk_test", clerk_js_version="6.99.0")
+
+    component = app.app_wraps[(1, "ClerkProvider")](None)
+    assert 'clerkJsVersion:"6.99.0"' in component.render()["props"]
+
+
+def test_configure_clerk_frontend_versions_updates_field_defaults():
+    from reflex_clerk_api.base import (
+        DEFAULT_CLERK_FRONTEND_VERSIONS,
+        configure_clerk_frontend_versions,
+        reset_clerk_frontend_versions,
+    )
+    from reflex_clerk_api.clerk_provider import ClerkProvider
+    from reflex_clerk_api.user_components import UserButton
+
+    try:
+        versions = configure_clerk_frontend_versions(
+            react_version="6.7.0",
+            ui_version="1.10.0",
+            clerk_js_version="6.11.0",
+        )
+
+        assert versions.react_library == "@clerk/react@6.7.0"
+        assert UserButton.library == versions.react_library
+        assert UserButton.lib_dependencies == list(versions.dependency_libraries)
+        assert UserButton.get_fields()["library"].default == versions.react_library
+        assert UserButton.get_fields()["lib_dependencies"].default == list(
+            versions.dependency_libraries
+        )
+        assert UserButton.create().library == versions.react_library
+        assert versions.react_library in UserButton.create()._get_imports()
+        assert ClerkProvider.create().add_imports().get(versions.ui_library) == ["ui"]
+        assert (
+            ClerkProvider.get_fields()["clerk_js_version"].default
+            == versions.clerk_js_version
+        )
+        assert 'clerkJsVersion:"6.11.0"' in ClerkProvider.create().render()["props"]
+    finally:
+        configure_clerk_frontend_versions(DEFAULT_CLERK_FRONTEND_VERSIONS)
+        reset_clerk_frontend_versions()
+
+
+def test_custom_component_reads_clerk_base_library_at_call_time():
+    from reflex_clerk_api.base import (
+        DEFAULT_CLERK_FRONTEND_VERSIONS,
+        ClerkBase,
+        configure_clerk_frontend_versions,
+    )
+
+    class CustomUserButton(rx.Component):
+        library = None
+        tag = "CustomUserButton"
+
+        def _get_imports(self):
+            return {ClerkBase.library: [ImportVar(tag="UserButton")]}
+
+    try:
+        configure_clerk_frontend_versions(
+            react_version="6.8.0",
+            ui_version="1.11.0",
+            clerk_js_version="6.12.0",
+        )
+
+        assert "@clerk/react@6.8.0" in CustomUserButton.create()._get_imports()
+    finally:
+        configure_clerk_frontend_versions(DEFAULT_CLERK_FRONTEND_VERSIONS)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime configuration to choose pinned Clerk frontend package versions used by components.

* **Documentation**
  * Getting started guide updated with default Clerk frontend package versions and instructions to override them.

* **Tests**
  * Expanded unit tests covering frontend-version wiring, import generation and default-field propagation.

* **Chores**
  * Package version bumped to 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->