### PR TITLE
Refresh Clerk session when auth context changes.

### DIFF
--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -437,7 +437,7 @@ class ClerkSessionSynchronizer(rx.Component):
         return [
             """
 function ClerkSessionSynchronizer({{ children }}) {{
-  const {{ getToken, isLoaded, isSignedIn }} = useAuth()
+  const {{ getToken, isLoaded, isSignedIn, orgId, sessionId, userId }} = useAuth()
   const [ addEvents ] = useContext(EventLoopContext)
   const lastSentRef = useRef({{ stateKey: null, addEvents: null }})
 
@@ -454,9 +454,10 @@ function ClerkSessionSynchronizer({{ children }}) {{
       // Wait for all dependencies to be ready.
       if (!isLoaded || !addEvents) return
 
-      // Deduplicate rapid calls, but remain reconnect-safe:
+      // Deduplicate rapid calls, but keep org/user/session switches visible to the backend.
       // addEvents identity changes across websocket reconnects, so include it in the key.
-      const stateKey = isSignedIn ? "signed_in" : "signed_out"
+      const signedInStateKey = ["signed_in", userId || "", orgId || "", sessionId || ""].join(":")
+      const stateKey = isSignedIn ? signedInStateKey : "signed_out"
       if (
         lastSentRef.current?.stateKey === stateKey &&
         lastSentRef.current?.addEvents === addEvents
@@ -489,7 +490,7 @@ function ClerkSessionSynchronizer({{ children }}) {{
       }} else {{
         addEvents([ReflexEvent("{state}.clear_clerk_session")])
       }}
-  }}, [isLoaded, isSignedIn, addEvents, getToken])
+  }}, [isLoaded, isSignedIn, userId, orgId, sessionId, addEvents, getToken])
 
   return (
       <>{{children}}</>

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -50,7 +50,14 @@ def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcach
     from reflex_clerk_api.clerk_provider import ClerkSessionSynchronizer
 
     js = ClerkSessionSynchronizer.create().add_custom_code()[0]
-    assert "[isLoaded, isSignedIn, addEvents, getToken]" in js
+    assert "orgId" in js
+    assert "sessionId" in js
+    assert "userId" in js
+    assert (
+        '[\"signed_in\", userId || \"\", orgId || \"\", sessionId || \"\"].join(\":\")'
+        in js
+    )
+    assert "[isLoaded, isSignedIn, userId, orgId, sessionId, addEvents, getToken]" in js
     assert "skipCache: true" in js
     assert "isJwtExpired(token)" in js
 


### PR DESCRIPTION
Include Clerk user, organization, and session identifiers in the frontend sync key so app auth-change handlers run immediately after workspace or account switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Clerk authentication provider to correctly synchronise session state across organisation, user, and session changes, improving reliability during account transitions.
  * Improved reconnection stability by ensuring authentication events are reliably dispatched during state transitions and reconnects.
  * Strengthened internal validation checks for accurate session synchronisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->