### PR TITLE
Fix Clerk auth reload race

### DIFF
--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import time
@@ -43,6 +42,11 @@ class ClerkState(rx.State):
     """Whether the auth state of the user has been checked yet.
     I.e., has Clerk sent a response to the frontend yet."""
 
+    _pending_auth_on_load_event_ids: list[str] = []
+    """Page on_load event IDs waiting for the frontend Clerk auth check."""
+    _auth_on_loads_released: bool = False
+    """Whether pending auth-gated on_load events were released by timeout."""
+
     claims: JWTClaims | None = None
     """The JWT claims of the user, if they are logged in."""
     user_id: str | None = None
@@ -50,6 +54,7 @@ class ClerkState(rx.State):
 
     # NOTE: ClassVar tells reflex it doesn't need to include these in the persisted state per instance.
     _auth_wait_timeout_seconds: ClassVar[float] = 1.0
+    _max_pending_auth_on_load_events: ClassVar[int] = 50
     _secret_key: ClassVar[str | None] = None
     """The Clerk secret_key set during clerk_provider creation."""
     _on_load_events: ClassVar[dict[uuid.UUID, EventType[()]]] = {}
@@ -80,12 +85,60 @@ class ClerkState(rx.State):
 
     @classmethod
     def set_auth_wait_timeout_seconds(cls, seconds: float) -> None:
-        """Sets the max time to wait for initial auth check before running other on_load events.
+        """Set the frontend auth fallback timeout value.
 
-        Note: on_load events will still be run after a timed out auth check.
-        Check ClerkState.auth_checked to see if auth check is complete.
+        Auth-gated on_load events are normally flushed by the frontend Clerk sync
+        event. If Clerk never reports loaded or token retrieval stalls, the
+        frontend releases queued on_load events after this timeout without
+        changing the current auth state.
         """
+        if seconds < 0:
+            raise ValueError("auth wait timeout must be non-negative")
         cls._auth_wait_timeout_seconds = seconds
+
+    @classmethod
+    def set_max_pending_auth_on_load_events(cls, max_events: int) -> None:
+        """Set the maximum number of auth-gated page on_loads pending per state."""
+        if max_events < 1:
+            raise ValueError("max pending auth on_load events must be at least 1")
+        cls._max_pending_auth_on_load_events = max_events
+
+    def _take_pending_auth_on_load_event_ids(self) -> list[str]:
+        pending_on_load_event_ids = list(
+            dict.fromkeys(self._pending_auth_on_load_event_ids)
+        )
+        self._pending_auth_on_load_event_ids = []
+        return pending_on_load_event_ids
+
+    @classmethod
+    def _get_on_load_events_for_id(cls, uid: uuid.UUID) -> list[IndividualEventType[()]]:
+        on_loads = cls._on_load_events.get(uid, None)
+        if on_loads is None:
+            logging.warning("Waited for auth, but no on_load events registered.")
+            return []
+        return list(on_loads)
+
+    @classmethod
+    def _get_on_load_events_for_ids(
+        cls, event_ids: list[str]
+    ) -> list[IndividualEventType[()]]:
+        on_loads: list[IndividualEventType[()]] = []
+        for event_id in dict.fromkeys(event_ids):
+            try:
+                uid = uuid.UUID(event_id)
+            except ValueError:
+                logging.warning("Ignoring invalid pending auth on_load event id.")
+                continue
+            on_loads.extend(cls._get_on_load_events_for_id(uid))
+        return on_loads
+
+    def _queue_pending_auth_on_load_event_id(self, uid: uuid.UUID) -> None:
+        event_id = str(uid)
+        pending_ids = list(dict.fromkeys(self._pending_auth_on_load_event_ids))
+        if event_id not in pending_ids:
+            pending_ids.append(event_id)
+        overflow_count = max(0, len(pending_ids) - self._max_pending_auth_on_load_events)
+        self._pending_auth_on_load_event_ids = pending_ids[overflow_count:]
 
     @classmethod
     def set_claims_options(cls, claims_options: dict[str, Any]) -> None:
@@ -163,14 +216,22 @@ class ClerkState(rx.State):
                 self.claims = None
                 self.user_id = None
                 self.auth_checked = True
-            return list(self._dependent_handlers.values())
+                self._auth_on_loads_released = False
+                pending_on_load_event_ids = self._take_pending_auth_on_load_event_ids()
+            pending_on_loads = self._get_on_load_events_for_ids(
+                pending_on_load_event_ids
+            )
+            return list(self._dependent_handlers.values()) + pending_on_loads
 
         async with self:
             self.is_signed_in = True
             self.claims = decoded
             self.user_id = str(decoded.get("sub"))
             self.auth_checked = True
-        return list(self._dependent_handlers.values())
+            self._auth_on_loads_released = False
+            pending_on_load_event_ids = self._take_pending_auth_on_load_event_ids()
+        pending_on_loads = self._get_on_load_events_for_ids(pending_on_load_event_ids)
+        return list(self._dependent_handlers.values()) + pending_on_loads
 
     @rx.event
     def clear_clerk_session(self) -> EventType:
@@ -179,38 +240,56 @@ class ClerkState(rx.State):
         This event is triggered by the frontend via the ClerkSessionSynchronizer/ClerkProvider component.
         """
         logging.debug("Clearing Clerk session")
+        pending_on_load_event_ids = self._take_pending_auth_on_load_event_ids()
         self.reset()
         self.auth_checked = True
-        return list(self._dependent_handlers.values())
+        self._auth_on_loads_released = False
+        pending_on_loads = self._get_on_load_events_for_ids(pending_on_load_event_ids)
+        return list(self._dependent_handlers.values()) + pending_on_loads
+
+    @rx.event
+    def release_pending_auth_on_loads(self) -> EventType:
+        """Release auth-gated page loads without changing auth state.
+
+        This preserves the previous timeout behavior of clerk.on_load: page load
+        handlers can still run after the configured timeout, but auth_checked
+        remains false until Clerk actually syncs.
+        """
+        logging.warning("Clerk auth sync timed out; releasing pending on_load events")
+        if self.auth_checked:
+            return []
+        self._auth_on_loads_released = True
+        pending_on_load_event_ids = self._take_pending_auth_on_load_event_ids()
+        pending_on_loads = self._get_on_load_events_for_ids(pending_on_load_event_ids)
+        return pending_on_loads
 
     @rx.event(background=True)
-    async def wait_for_auth_check(self, uid: uuid.UUID | str) -> EventType:
-        """Wait for the Clerk authentication to complete (event sent from frontend).
+    async def wait_for_auth_check(
+        self, uid: uuid.UUID | str
+    ) -> EventType:
+        """Run page on_load events once Clerk authentication has been checked.
 
-        Can't just use a blocking wait_for_auth_check because we are really waiting for the frontend event trigger to run, so we need to not block that while we wait.
-
-        This can then return on_load events once auth_checked is True.
+        If the frontend auth event has not reached the backend yet, queue this
+        page on_load ID on the state instance. The Clerk sync event will flush it.
         """
         uid = uuid.UUID(uid) if isinstance(uid, str) else uid
         logging.debug(f"Waiting for auth check: {uid} ({type(uid)})")
 
-        on_loads = self._on_load_events.get(uid, None)
-        if on_loads is None:
-            logging.warning("Waited for auth, but no on_load events registered.")
-            on_loads = []
+        on_loads = self._get_on_load_events_for_id(uid)
+        if not on_loads:
+            return []
 
-        deadline = time.monotonic() + ClerkState._auth_wait_timeout_seconds
-        while time.monotonic() < deadline:
-            async with self:
-                auth_checked = self.auth_checked
-            if auth_checked:
-                logging.debug("Auth check complete")
-                return on_loads
-            logging.debug("...waiting for auth...")
-            # TODO: Ideally, wait on some event instead of sleeping
-            await asyncio.sleep(0.05)
-        logging.warning("Auth check timed out")
-        return on_loads
+        async with self:
+            auth_checked = self.auth_checked
+            auth_on_loads_released = self._auth_on_loads_released
+            already_pending = str(uid) in self._pending_auth_on_load_event_ids
+            if not auth_checked and not auth_on_loads_released and not already_pending:
+                self._queue_pending_auth_on_load_event_id(uid)
+
+        if auth_checked or auth_on_loads_released:
+            logging.debug("Auth check complete")
+            return self._get_on_load_events_for_id(uid)
+        return []
 
     @classmethod
     def _set_secret_key(cls, secret_key: str) -> None:
@@ -433,6 +512,7 @@ class ClerkSessionSynchronizer(rx.Component):
 
     def add_custom_code(self) -> list[str]:
         clerk_state_name = ClerkState.get_full_name()
+        auth_timeout_ms = max(0, int(ClerkState._auth_wait_timeout_seconds * 1000))
 
         return [
             """
@@ -440,6 +520,7 @@ function ClerkSessionSynchronizer({{ children }}) {{
   const {{ getToken, isLoaded, isSignedIn, orgId, sessionId, userId }} = useAuth()
   const [ addEvents ] = useContext(EventLoopContext)
   const lastSentRef = useRef({{ stateKey: null, addEvents: null }})
+  const authFallbackTimerRef = useRef(null)
 
   const isJwtExpired = (token) => {{
     try {{
@@ -449,6 +530,29 @@ function ClerkSessionSynchronizer({{ children }}) {{
       return false
     }}
   }}
+
+  useEffect(() => {{
+      if (!addEvents) return
+      if (authFallbackTimerRef.current !== null) {{
+        clearTimeout(authFallbackTimerRef.current)
+        authFallbackTimerRef.current = null
+      }}
+      if (isLoaded) {{
+        return
+      }}
+      authFallbackTimerRef.current = setTimeout(() => {{
+        authFallbackTimerRef.current = null
+        // Fallback only if Clerk never reports loaded. This preserves the old
+        // timeout behavior without treating a slow Clerk load as logout.
+        addEvents([ReflexEvent("{state}.release_pending_auth_on_loads")])
+      }}, {auth_timeout_ms})
+      return () => {{
+        if (authFallbackTimerRef.current !== null) {{
+          clearTimeout(authFallbackTimerRef.current)
+          authFallbackTimerRef.current = null
+        }}
+      }}
+  }}, [isLoaded, addEvents])
 
   useEffect(() => {{
       // Wait for all dependencies to be ready.
@@ -461,33 +565,72 @@ function ClerkSessionSynchronizer({{ children }}) {{
       if (
         lastSentRef.current?.stateKey === stateKey &&
         lastSentRef.current?.addEvents === addEvents
-      ) return
-      lastSentRef.current = {{ stateKey, addEvents }}
-
-      if (isSignedIn) {{
-        // Prefer a fresh token; cached tokens can be close to expiry.
-        // If this Clerk version doesn't support skipCache, fall back to the default call.
-        Promise.resolve()
+      ) {{
+        return
+      }}
+      let cancelled = false
+      let tokenRetryTimer = null
+      let pendingOnLoadsReleased = false
+      const releasePendingOnLoads = () => {{
+        if (cancelled || pendingOnLoadsReleased) return
+        pendingOnLoadsReleased = true
+        addEvents([ReflexEvent("{state}.release_pending_auth_on_loads")])
+      }}
+      const scheduleTokenRetry = () => {{
+        if (cancelled || tokenRetryTimer !== null) return
+        tokenRetryTimer = setTimeout(() => {{
+          tokenRetryTimer = null
+          requestToken()
+        }}, {auth_timeout_ms})
+      }}
+      const requestToken = () => {{
+        const tokenRequest = Promise.resolve()
           .then(() => getToken({{ skipCache: true }}))
           .catch(() => getToken())
+        const tokenTimeout = new Promise(resolve => {{
+          setTimeout(() => resolve(null), {auth_timeout_ms})
+        }})
+        // Prefer a fresh token; cached tokens can be close to expiry.
+        // If this Clerk version doesn't support skipCache, fall back to the default call.
+        Promise.race([tokenRequest, tokenTimeout])
           .then(token => {{
+            if (cancelled) return
             if (token) {{
               if (isJwtExpired(token)) {{
                 // Avoid sending already-expired JWTs to the backend, which would otherwise leave
                 // auth waiters racing a validation failure.
+                lastSentRef.current = {{ stateKey, addEvents }}
                 addEvents([ReflexEvent("{state}.clear_clerk_session")])
                 return
               }}
+              lastSentRef.current = {{ stateKey, addEvents }}
               addEvents([ReflexEvent("{state}.set_clerk_session", {{token}})])
             }} else {{
-              // Token unavailable despite isSignedIn - clear to avoid stuck auth state.
-              addEvents([ReflexEvent("{state}.clear_clerk_session")])
+              // Token unavailable despite isSignedIn. Release on_loads after the
+              // timeout path, but keep retrying instead of treating it as logout.
+              releasePendingOnLoads()
+              scheduleTokenRetry()
             }}
           }}).catch(() => {{
-            // Token retrieval failed - clear to avoid stuck auth state.
-            addEvents([ReflexEvent("{state}.clear_clerk_session")])
+            if (cancelled) return
+            // Token retrieval failed. Keep Clerk authoritative; a later successful
+            // sync or explicit signed-out state will reconcile.
+            releasePendingOnLoads()
+            scheduleTokenRetry()
           }})
+      }}
+
+      if (isSignedIn) {{
+        requestToken()
+        return () => {{
+          cancelled = true
+          if (tokenRetryTimer !== null) {{
+            clearTimeout(tokenRetryTimer)
+            tokenRetryTimer = null
+          }}
+        }}
       }} else {{
+        lastSentRef.current = {{ stateKey, addEvents }}
         addEvents([ReflexEvent("{state}.clear_clerk_session")])
       }}
   }}, [isLoaded, isSignedIn, userId, orgId, sessionId, addEvents, getToken])
@@ -496,7 +639,7 @@ function ClerkSessionSynchronizer({{ children }}) {{
       <>{{children}}</>
   )
 }}
-""".format(state=clerk_state_name)
+""".format(state=clerk_state_name, auth_timeout_ms=auth_timeout_ms)
         ]
 
 

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -90,10 +90,10 @@ class ClerkState(rx.State):
         Auth-gated on_load events are normally flushed by the frontend Clerk sync
         event. If Clerk never reports loaded or token retrieval stalls, the
         frontend releases queued on_load events after this timeout without
-        changing the current auth state.
+        changing the current auth state. The timeout must be positive.
         """
-        if seconds < 0:
-            raise ValueError("auth wait timeout must be non-negative")
+        if seconds <= 0:
+            raise ValueError("auth wait timeout must be positive")
         cls._auth_wait_timeout_seconds = seconds
 
     @classmethod
@@ -607,7 +607,6 @@ function ClerkSessionSynchronizer({{ children }}) {{
               if (isJwtExpired(token)) {{
                 // Avoid sending already-expired JWTs to the backend, which would otherwise leave
                 // auth waiters racing a validation failure.
-                lastSentRef.current = {{ stateKey, addEvents }}
                 addEvents([ReflexEvent("{state}.clear_clerk_session")])
                 return
               }}

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -138,6 +138,14 @@ class ClerkState(rx.State):
         if event_id not in pending_ids:
             pending_ids.append(event_id)
         overflow_count = max(0, len(pending_ids) - self._max_pending_auth_on_load_events)
+        if overflow_count > 0:
+            logging.warning(
+                "Dropping %s oldest pending auth on_load event(s) due to queue "
+                "overflow; max pending events=%s, dropped event ids=%s",
+                overflow_count,
+                self._max_pending_auth_on_load_events,
+                pending_ids[:overflow_count],
+            )
         self._pending_auth_on_load_event_ids = pending_ids[overflow_count:]
 
     @classmethod

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 
 import authlib.jose.errors as jose_errors
 import reflex as rx
@@ -60,6 +61,136 @@ def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcach
     assert "[isLoaded, isSignedIn, userId, orgId, sessionId, addEvents, getToken]" in js
     assert "skipCache: true" in js
     assert "isJwtExpired(token)" in js
+    assert "setTimeout" in js
+    assert "release_pending_auth_on_loads" in js
+    assert "clear_clerk_session" in js
+    assert "Promise.race([tokenRequest, tokenTimeout])" in js
+    assert "scheduleTokenRetry()" in js
+
+
+def test_clerk_session_synchronizer_js_uses_configured_auth_fallback_timeout():
+    """The frontend fallback timeout should use ClerkState configuration."""
+    from reflex_clerk_api.clerk_provider import ClerkSessionSynchronizer, ClerkState
+
+    original_timeout = ClerkState._auth_wait_timeout_seconds
+    try:
+        ClerkState.set_auth_wait_timeout_seconds(2.5)
+        js = ClerkSessionSynchronizer.create().add_custom_code()[0]
+    finally:
+        ClerkState.set_auth_wait_timeout_seconds(original_timeout)
+
+    assert "}, 2500)" in js
+
+
+def test_wait_for_auth_check_queues_and_set_clerk_session_flushes(monkeypatch):
+    """Auth-gated on_loads should flush when the Clerk session sync succeeds."""
+    import importlib
+
+    clerk_provider_module = importlib.import_module("reflex_clerk_api.clerk_provider")
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    state = ClerkState(_reflex_internal_init=True)
+    uid = uuid.uuid4()
+    on_load_event = rx.noop()
+    ClerkState._on_load_events = {uid: [on_load_event]}
+
+    async def fake_get_jwk_keys(self):
+        return {}
+
+    class FakeClaims(dict):
+        def validate(self, leeway=None):
+            return None
+
+    monkeypatch.setattr(ClerkState, "_get_jwk_keys", fake_get_jwk_keys, raising=True)
+    monkeypatch.setattr(
+        clerk_provider_module.jwt,
+        "decode",
+        lambda *args, **kwargs: FakeClaims(sub="user_123"),
+        raising=True,
+    )
+
+    queued = asyncio.run(ClerkState.wait_for_auth_check.fn(state, uid=uid))
+    assert queued == []
+    assert state._pending_auth_on_load_event_ids == [str(uid)]
+
+    flushed = asyncio.run(ClerkState.set_clerk_session.fn(state, token="fake"))
+    assert flushed == [on_load_event]
+    assert state.auth_checked is True
+    assert state.is_signed_in is True
+    assert state.user_id == "user_123"
+    assert state._pending_auth_on_load_event_ids == []
+    assert ClerkState._on_load_events[uid] == [on_load_event]
+
+    next_state = ClerkState(_reflex_internal_init=True)
+    next_state.auth_checked = True
+    repeat = asyncio.run(ClerkState.wait_for_auth_check.fn(next_state, uid=uid))
+    assert repeat == [on_load_event]
+
+
+def test_wait_for_auth_check_queues_and_timeout_releases_without_state_change():
+    """Frontend auth timeout should not be treated as an auth result."""
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    state = ClerkState(_reflex_internal_init=True)
+    state.is_signed_in = True
+    state.user_id = "user_existing"
+    uid = uuid.uuid4()
+    on_load_event = rx.noop()
+    ClerkState._on_load_events = {uid: [on_load_event]}
+
+    queued = asyncio.run(ClerkState.wait_for_auth_check.fn(state, uid=uid))
+    assert queued == []
+
+    flushed = ClerkState.release_pending_auth_on_loads.fn(state)
+    assert flushed == [on_load_event]
+    assert state.auth_checked is False
+    assert state.is_signed_in is True
+    assert state.user_id == "user_existing"
+    assert state._pending_auth_on_load_event_ids == []
+    assert ClerkState._on_load_events[uid] == [on_load_event]
+
+
+def test_auth_timeout_before_queue_does_not_strand_on_load():
+    """If timeout arrives before wait_for_auth_check, on_load still runs."""
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    state = ClerkState(_reflex_internal_init=True)
+    uid = uuid.uuid4()
+    on_load_event = rx.noop()
+    ClerkState._on_load_events = {uid: [on_load_event]}
+
+    released = ClerkState.release_pending_auth_on_loads.fn(state)
+    assert released == []
+    assert state.auth_checked is False
+    assert state._auth_on_loads_released is True
+
+    on_loads = asyncio.run(ClerkState.wait_for_auth_check.fn(state, uid=uid))
+    assert on_loads == [on_load_event]
+    assert state._pending_auth_on_load_event_ids == []
+    assert ClerkState._on_load_events[uid] == [on_load_event]
+
+
+def test_wait_for_auth_check_queues_and_clear_clerk_session_flushes(monkeypatch):
+    """An explicit signed-out sync should flush queued on_loads as signed-out."""
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    state = ClerkState(_reflex_internal_init=True)
+    uid = uuid.uuid4()
+    on_load_event = rx.noop()
+    ClerkState._on_load_events = {uid: [on_load_event]}
+
+    queued = asyncio.run(ClerkState.wait_for_auth_check.fn(state, uid=uid))
+    assert queued == []
+
+    # Bare ClerkState instances do not have a parent root state in unit tests,
+    # so bypass Reflex's full-tree reset and isolate this handler's behavior.
+    monkeypatch.setattr(ClerkState, "reset", lambda self: None, raising=True)
+    flushed = ClerkState.clear_clerk_session.fn(state)
+    assert flushed == [on_load_event]
+    assert state.auth_checked is True
+    assert state.is_signed_in is False
+    assert state._pending_auth_on_load_event_ids == []
+    assert ClerkState._on_load_events[uid] == [on_load_event]
 
 
 def test_clerk_session_synchronizer_imports_pinned_clerk_react():

--- a/tests/test_clerk_provider_unit.py
+++ b/tests/test_clerk_provider_unit.py
@@ -2,6 +2,7 @@ import asyncio
 import uuid
 
 import authlib.jose.errors as jose_errors
+import pytest
 import reflex as rx
 from reflex.utils.imports import ImportVar
 
@@ -66,6 +67,11 @@ def test_clerk_session_synchronizer_js_contains_reconnect_safe_deps_and_skipcach
     assert "clear_clerk_session" in js
     assert "Promise.race([tokenRequest, tokenTimeout])" in js
     assert "scheduleTokenRetry()" in js
+    expired_token_start = js.index("if (isJwtExpired(token))")
+    expired_token_branch = js[
+        expired_token_start : js.index("clear_clerk_session", expired_token_start)
+    ]
+    assert "lastSentRef.current" not in expired_token_branch
 
 
 def test_clerk_session_synchronizer_js_uses_configured_auth_fallback_timeout():
@@ -80,6 +86,20 @@ def test_clerk_session_synchronizer_js_uses_configured_auth_fallback_timeout():
         ClerkState.set_auth_wait_timeout_seconds(original_timeout)
 
     assert "}, 2500)" in js
+
+
+def test_set_auth_wait_timeout_seconds_requires_positive_value():
+    """Zero would create immediate frontend timeout/retry loops."""
+    from reflex_clerk_api.clerk_provider import ClerkState
+
+    original_timeout = ClerkState._auth_wait_timeout_seconds
+    try:
+        with pytest.raises(ValueError, match="auth wait timeout must be positive"):
+            ClerkState.set_auth_wait_timeout_seconds(0)
+        with pytest.raises(ValueError, match="auth wait timeout must be positive"):
+            ClerkState.set_auth_wait_timeout_seconds(-0.1)
+    finally:
+        ClerkState.set_auth_wait_timeout_seconds(original_timeout)
 
 
 def test_wait_for_auth_check_queues_and_set_clerk_session_flushes(monkeypatch):


### PR DESCRIPTION
## Summary
- Refresh Clerk session sync when the Clerk auth context changes across user, org, session, and websocket reconnect boundaries.
- Replace backend polling for auth-gated `on_load` handlers with per-state queued IDs flushed by Clerk sync or timeout release.
- Keep registered `on_load` handlers reusable across reloads and retry signed-in token sync after transient token timeouts/failures.

## Test plan
- `python -m pytest tests/test_clerk_provider_unit.py`
- `python -m pytest tests --ignore=tests/test_demo.py`
- `python -m ruff check custom_components/reflex_clerk_api/clerk_provider.py tests/test_clerk_provider_unit.py`
- Manual app reload smoke test: confirmed app gets past loading and no repeated missing on_load registration warnings.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented authentication hang-ups with a timed frontend fallback that releases pending auth-gated load events.
  * Improved token handling to avoid immediate sign-out when tokens are temporarily unavailable, adding cancellation and retry logic.

* **New Features**
  * Configurable queuing limit for auth-gated load events and a backend-triggered release mechanism that doesn't alter auth state.

* **Tests**
  * Added unit and regression tests covering timeout releases, queued-event flushing on sign-in/sign-out, and token retry behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snap-analytics/reflex-clerk-api/pull/8)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->